### PR TITLE
Display issues with collaborators

### DIFF
--- a/lib/collaborators.rb
+++ b/lib/collaborators.rb
@@ -1,11 +1,14 @@
 class RepoCollab
-  attr_reader :repository, :login, :repo_url, :login_url
+  attr_reader :repository, :login, :repo_url, :login_url, :issues, :href, :permission
 
   def initialize(hash)
     @repository = hash.fetch("repository")
     @repo_url = hash.fetch("repo_url")
     @login = hash.fetch("login")
     @login_url = hash.fetch("login_url")
+    @issues = hash.fetch("issues")
+    @href = hash.fetch("href")
+    @permission = hash.fetch("permission")
   end
 end
 

--- a/lib/collaborators.rb
+++ b/lib/collaborators.rb
@@ -22,16 +22,16 @@ class Collaborators < ItemList
 
   def repositories
     list
-      .inject({}) { |hash, i| hash[i.repository] = i; hash }
+      .each_with_object({}) { |i, hash| hash[i.repository] = i; }
       .values
-      .sort { |a,b| a.repository <=> b.repository }
+      .sort_by(&:repository)
   end
 
   def collaborators
     list
-      .inject({}) { |hash, i| hash[i.login] = i; hash }
+      .each_with_object({}) { |i, hash| hash[i.login] = i; }
       .values
-      .sort { |a,b| a.login <=> b.login }
+      .sort_by(&:login)
   end
 
   def repository_collaborators(repo_name)

--- a/views/github_collaborators.erb
+++ b/views/github_collaborators.erb
@@ -24,12 +24,26 @@
         <table class="table table-striped">
           <thead class="thead-dark">
             <tr>
-              <th> <%= link_to collab.login, collab.login_url %> </th>
+              <th> Collaborator: <%= link_to collab.login, collab.login_url %> </th>
             </tr>
           </thead>
           <% data.collaborator_repositories(collab.login).each do |repo| %>
             <tr>
-              <td> <%= link_to repo.repository, repo.repo_url %> </td>
+              <td>
+                <p>Repository: <%= link_to repo.repository, repo.repo_url %></p>
+                <p>
+                  Issues:
+                  <ol>
+                    <% repo.issues.each do |issue| %>
+                      <li> <%= issue %> </li>
+                    <% end %>
+                  </ol>
+                </p>
+                <p>
+                  Please use this link to raise a PR to fix these issues:
+                  <a href="<%= repo.href %>" class="badge badge-pill badge-primary">edit collaborator definition</a>
+                </p>
+              </td>
             </tr>
           <% end %>
         </table>
@@ -48,12 +62,26 @@
         <table class="table table-striped">
           <thead class="thead-dark">
             <tr>
-              <th> <%= link_to repo.repository, repo.repo_url %> </th>
+              <th> Repository: <%= link_to repo.repository, repo.repo_url %> </th>
             </tr>
           </thead>
           <% data.repository_collaborators(repo.repository).each do |collab| %>
             <tr>
-              <td> <%= link_to collab.login, collab.login_url %> </td>
+              <td>
+                <p>Collaborator: <%= link_to collab.login, collab.login_url %></p>
+                <p>
+                  Issues:
+                  <ol>
+                    <% collab.issues.each do |issue| %>
+                      <li> <%= issue %> </li>
+                    <% end %>
+                  </ol>
+                </p>
+                <p>
+                  Please use this link to raise a PR to fix these issues:
+                  <a href="<%= collab.href %>" class="badge badge-pill badge-primary">edit collaborator definition</a>
+                </p>
+              </td>
             </tr>
           <% end %>
         </table>


### PR DESCRIPTION
Only collaborators with issues (i.e. problems which need to be fixed)
will appear in the JSON data posted to this report. This change displays
those issues along with a link to the repo where the user can fix them.
