### PR TITLE
Add a count to collaborators report

### DIFF
--- a/views/github_collaborators.erb
+++ b/views/github_collaborators.erb
@@ -1,4 +1,7 @@
-<h1>GitHub Collaborators</h1>
+<% if data.list.any? %>
+  <% total = " (#{data.list.size})" %>
+<% end %>
+<h1>GitHub Collaborators<%= total %></h1>
 
 <p>
   GitHub users with access to ministryofjustice repositories


### PR DESCRIPTION
This change shows the total number of collaborations which need
to be fixed (i.e. they need additional details provided, or haven't been
defined in terraform code yet).

This should make it easier to judge our progress in getting teams to
update the information in this repo.
