### PR TITLE
Add a new API route for a deeper dynamic badge

### DIFF
--- a/report_app/main/views.py
+++ b/report_app/main/views.py
@@ -349,6 +349,7 @@ def compliant_repository(repository_name):
                 return {"result": "PASS"}
     return {"result": "FAIL"}
 
+
 @main.route('/api/v1/compliant_public_repositories/endpoint/<repository_name>', methods=['GET'])
 def compliant_repository_endpoint(repository_name):
     """Find a repository in compliant repositories list
@@ -365,5 +366,5 @@ def compliant_repository_endpoint(repository_name):
         compliant_repos = repository.get_compliant_repositories()
         for compliant_repo in compliant_repos:
             if compliant_repo.get("name") == repository_name:
-                return {"schemaVersion": 1,"label": "MoJ Compliant","message": "PASS"}
-    return {"schemaVersion": 1,"label": "MoJ Compliant","message": "FAIL","color": "d4351c"}
+                return {"schemaVersion": 1, "label": "MoJ Compliant", "message": "PASS"}
+    return {"schemaVersion": 1, "label": "MoJ Compliant", "message": "FAIL", "color": "d4351c"}

--- a/report_app/main/views.py
+++ b/report_app/main/views.py
@@ -348,3 +348,22 @@ def compliant_repository(repository_name):
             if compliant_repo.get("name") == repository_name:
                 return {"result": "PASS"}
     return {"result": "FAIL"}
+
+@main.route('/api/v1/compliant_public_repositories/endpoint/<repository_name>', methods=['GET'])
+def compliant_repository_endpoint(repository_name):
+    """Find a repository in compliant repositories list
+
+    Args:
+        repository_name (string): name of repository to find
+
+    Returns:
+        dict: json result true if find repository in compliant repositories list
+    """
+    logger.debug("compliant_repository_endpoint()")
+    repository = Repositories("public")
+    if repository.is_database_ready():
+        compliant_repos = repository.get_compliant_repositories()
+        for compliant_repo in compliant_repos:
+            if compliant_repo.get("name") == repository_name:
+                return {"schemaVersion": 1,"label": "MoJ Compliant","message": "PASS"}
+    return {"schemaVersion": 1,"label": "MoJ Compliant","message": "FAIL","color": "d4351c"}


### PR DESCRIPTION
This PR is a value add. The previous route has not been adjusted.

I've tested this locally. This is the response from:

http://127.0.0.1:4567/api/v1/compliant_public_repositories/endpoint/operations-engineering

```
{
  "color": "d4351c",
  "label": "MoJ Compliant",
  "message": "FAIL",
  "schemaVersion": 1
}
```

Please let me know if you'd like the URL to be something different. Thank you.

