### PR TITLE
Prevent user override on error

### DIFF
--- a/report_app/main/views.py
+++ b/report_app/main/views.py
@@ -366,5 +366,5 @@ def compliant_repository_endpoint(repository_name):
         compliant_repos = repository.get_compliant_repositories()
         for compliant_repo in compliant_repos:
             if compliant_repo.get("name") == repository_name:
-                return {"schemaVersion": 1, "label": "MoJ Compliant", "message": "PASS"}
-    return {"schemaVersion": 1, "label": "MoJ Compliant", "message": "FAIL", "color": "d4351c"}
+                return {"schemaVersion": 1, "label": "MoJ Compliant", "message": "PASS", "color": "005ea5"}
+    return {"schemaVersion": 1, "label": "MoJ Compliant", "message": "FAIL", "color": "d4351c", "isError": "true"}


### PR DESCRIPTION
Fix the colour issue on the FAIL response; the button colour stays blue because the user has specified it in the URL.

> When a user specifies `color=...` in the URL, shield.io honors this.

> When `isError=true`, shield.io will ignore the user-specified `color` in the URL.

Furthermore; the default MoJ blue has been applied to the PASS response.