### PR TITLE
Add our crest to the response

### DIFF
--- a/report_app/main/views.py
+++ b/report_app/main/views.py
@@ -393,17 +393,17 @@ OllFX/i53P5P9a/gNkKpsCMFRuFAAAAABJRU5ErkJggg=="""
         for compliant_repo in compliant_repos:
             if compliant_repo.get("name") == repository_name:
                 return {
-                         "schemaVersion": 1,
-                         "label": "MoJ Compliant",
-                         "message": "PASS",
-                         "color": "005ea5",
-                         "namedLogo": moj_crest
-                       }
+                    "schemaVersion": 1,
+                    "label": "MoJ Compliant",
+                    "message": "PASS",
+                    "color": "005ea5",
+                    "namedLogo": moj_crest
+                }
     return {
-             "schemaVersion": 1,
-             "label": "MoJ Compliant",
-             "message": "FAIL",
-             "color": "d4351c",
-             "isError": "true",
-             "namedLogo": moj_crest
-           }
+        "schemaVersion": 1,
+        "label": "MoJ Compliant",
+        "message": "FAIL",
+        "color": "d4351c",
+        "isError": "true",
+        "namedLogo": moj_crest
+    }

--- a/report_app/main/views.py
+++ b/report_app/main/views.py
@@ -361,10 +361,49 @@ def compliant_repository_endpoint(repository_name):
         dict: json result true if find repository in compliant repositories list
     """
     logger.debug("compliant_repository_endpoint()")
+
+    # MoJ crest in PNG, base64 format
+    moj_crest = """data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAABmJLR0QA/wD/AP+gvaeTAAAHJElEQVR
+Yhe2YeYyW1RWHnzuMCzCIglBQlhSV2gICKlHiUhVBEAsxGqmVxCUUIV1i61YxadEoal1SWttUaKJNWrQUsRRc6tLGNlCXWGyoUkCJ4uCCSCOiwlTm6R
+/nfPjyMeDY8lfjSSZz3/fee87vnnPu75z3g8/kM2mfqMPVH6mf35t6G/ZgcJ/836Gdug4FjgO67UFn70+FDmjcw9xZaiegWX29lLLmE3QV4Glg8x7Wb
+FfHlFIebS/ANj2oDgX+CXwA9AMubmPNvuqX1SnqKGAT0BFoVE9UL1RH7nSCUjYAL6rntBdg2Q3AgcAo4HDgXeBAoC+wrZQyWS3AWcDSUsomtSswEtgX
+aAGWlVI2q32BI0spj9XpPww4EVic88vaC7iq5Hz1BvVf6v3qe+rb6ji1p3pWrmtQG9VD1Jn5br+Knmm70T9MfUh9JaPQZu7uLsR9gEsJb3QF9gOagO7
+AuUTom1LpCcAkoCcwQj0VmJregzaipA4GphNe7w/MBearB7QLYCmlGdiWSm4CfplTHwBDgPHAFmB+Ah8N9AE6EGkxHLhaHU2kRhXc+cByYCqROs05NQ
+q4oR7Lnm5xE9AL+GYC2gZ0Jmjk8VLKO+pE4HvAyYRnOwOH5N7NhMd/WKf3beApYBWwAdgHuCLn+tatbRtgJv1awhtd838LEeq30/A7wN+AwcBt+bwpD
+9AdOAkYVkpZXtVdSnlc7QI8BlwOXFmZ3oXkdxfidwmPrQXeA+4GuuT08QSdALxC3OYNhBe/TtzON4EziZBXD36o+q082BxgQuqvyYL6wtBY2TyEyJ2D
+gAXAzcC1+Xxw3RlGqiuJ6vE6QS9VGZ/7H02DDwAvELTyMDAxbfQBvggMAAYR9LR9J2cluH7AmnzuBowFFhLJ/wi7yiJgGXBLPq8A7idy9kPgvAQPcC9
+wERHSVcDtCfYj4E7gr8BRqWMjcXmeB+4tpbyG2kG9Sl2tPqF2Uick8B+7szyfvDhR3Z7vvq/2yqpynnqNeoY6v7LvevUU9QN1fZ3OTeppWZmeyzRoVu
++rhbaHOledmoQ7LRd3SzBVeUo9Wf1DPs9X90/jX8m/e9Rn1Mnqi7nuXXW5+rK6oU7n64mjszovxyvVh9WeDcTVnl5KmQNcCMwvpbQA1xE8VZXhwDXAz
+4FWIkfnAlcBAwl6+SjD2wTcmPtagZnAEuA3dTp7qyNKKe8DW9UeBCeuBsbsWKVOUPvn+MRKCLeq16lXqLPVFvXb6r25dlaGdUx6cITaJ8fnpo5WI4Wu
+zcjcqn5Y8eI/1F+n3XvUA1N3v4ZamIEtpZRX1Y6Z/DUK2g84GrgHuDqTehpBCYend94jbnJ34DDgNGArQT9bict3Y3p1ZCnlSoLQb0sbgwjCXpY2blc
+7llLW1UAMI3o5CD4bmuOlwHaC6xakgZ4Z+ibgSxnOgcAI4uavI27jEII7909dL5VSrimlPKgeQ6TJCZVQjwaOLaW8BfyWbPEa1SaiTH1VfSENd85NDx
+Ht1plA71LKRvX4BDaAKFlTgLeALtliDUqPrSV6SQCBlypgFlbmIIrCDcAl6nPAawmYhlLKFuB6IrkXAadUNj6TXlhDcCNEB/Jn4FcE0f4UWEl0NyWNv
+ZxGTs89z6ZnatIIrCdqcCtRJmcCPwCeSN3N1Iu6T4VaFhm9n+riypouBnepLsk9p6p35fzwvDSX5eVQvaDOzjnqzTl+1KC53+XzLINHd65O6lD1DnWb
+epPBhQ3q2jQyW+2oDkkAtdt5udpb7W+Q/OFGA7ol1zxu1tc8zNHqXercfDfQIOZm9fR815Cpt5PnVqsr1F51wI9QnzU63xZ1o/rdPPmt6enV6sXqHPV
+qdXOCe1rtrg5W7zNI+m712Ir+cer4POiqfHeJSVe1Raemwnm7xD3mD1E/Z3wIjcsTdlZnqO8bFeNB9c30zgVG2euYa69QJ+9G90lG+99bfdIoo5PU4w
+362xHePxl1slMab6tV72KUxDvzlAMT8G0ZohXq39VX1bNzzxij9K1Qb9lhdGe931B/kR6/zCwY9YvuytCsMlj+gbr5SemhqkyuzE8xau4MP865JvWNu
+j0b1YuqDkgvH2GkURfakly01Cg7Cw0+qyXxkjojq9Lw+vT2AUY+DlF/otYq1Ixc35re2V7R8aTRg2KUv7+ou3x/14PsUBn3NG51S0XpG0Z9PcOPKWSS
+0SKNUo9Rv2Mmt/G5WpPF6pHGra7Jv410OVsdaz217AbkAPX3ubkm240belCuudT4Rp5p/DyC2lf9mfq1iq5eFe8/lu+K0YrVp0uret4nAkwlB6vzjI/
+1PxrlrTp/oNHbzTJI92T1qAT+BfW49MhMg6JUp7ehY5a6Tl2jjmVvitF9fxo5Yq8CaAfAkzLMnySt6uz/1k6bPx59CpCNxGfoSKA30IPoH7cQXdArwC
+OllFX/i53P5P9a/gNkKpsCMFRuFAAAAABJRU5ErkJggg=="""
+
     repository = Repositories("public")
     if repository.is_database_ready():
         compliant_repos = repository.get_compliant_repositories()
         for compliant_repo in compliant_repos:
             if compliant_repo.get("name") == repository_name:
-                return {"schemaVersion": 1, "label": "MoJ Compliant", "message": "PASS", "color": "005ea5"}
-    return {"schemaVersion": 1, "label": "MoJ Compliant", "message": "FAIL", "color": "d4351c", "isError": "true"}
+                return {
+                         "schemaVersion": 1,
+                         "label": "MoJ Compliant",
+                         "message": "PASS",
+                         "color": "005ea5",
+                         "namedLogo": moj_crest
+                       }
+    return {
+             "schemaVersion": 1,
+             "label": "MoJ Compliant",
+             "message": "FAIL",
+             "color": "d4351c",
+             "isError": "true",
+             "namedLogo": moj_crest
+           }


### PR DESCRIPTION
This PR adds our logo to the API response for users who use the `endpoint` badge.

This means that the logo doesn't need to be specified in the badge code. It shall appear.

Dev note: there is probably a better way of referencing the base64 code for use in the method.
Please advise 👍🏽 
Thanks