### PR TITLE
Add labelColor to badge API PASS response

### DIFF
--- a/report_app/main/views.py
+++ b/report_app/main/views.py
@@ -371,6 +371,7 @@ def compliant_repository_endpoint(repository_name):
                     "label": "MoJ Compliant",
                     "message": "PASS",
                     "color": "005ea5",
+                    "labelColor": "231f20",
                     "style": "for-the-badge"
                 }
     return {


### PR DESCRIPTION
Adds the `labelColor` property to the badge API PASS response. 

This will make our badge code less reliant on configuration.