### PR TITLE
:stethoscope: Remove broken Helm test until it can be replaced

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -69,7 +69,3 @@ jobs:
             --set application.apiKey=${OPERATIONS_ENGINEERING_REPORTS_API_KEY} \
             --set image.repository=754256621582.dkr.ecr.eu-west-2.amazonaws.com/${ECR_NAME} \
             --set ingress.host=operations-engineering-reports-dev.cloud-platform.service.justice.gov.uk
-
-      - name: Helm test
-        run: |
-          helm test operations-engineering-reports-dev --namespace ${KUBE_NAMESPACE}


### PR DESCRIPTION
The Helm test command can be very useful, but it doesn't run in Cloud Platform in its current inplementation. You cannot run root images in CP unless you're an admin, and we are not. Until this is replaced with something better I think it's best to remove the test.
