### PR TITLE
✨ Add links to high level report overview

### DIFF
--- a/report_app/main/report_database.py
+++ b/report_app/main/report_database.py
@@ -107,3 +107,13 @@ class ReportDatabase:
             raise ClientError("An error occurred while getting the report from the table: %s", err)
         else:
             return response['Item']
+
+    def get_all_compliant_repository_reports(self) -> list[dict]:
+        """Get all compliant repository reports from the database."""
+        reports = self.get_all_repository_reports()
+        return [report for report in reports if report["data"]["status"]]
+
+    def get_all_non_compliant_repository_reports(self) -> list[dict]:
+        """Get all non-compliant repository reports from the database."""
+        reports = self.get_all_repository_reports()
+        return [report for report in reports if not report["data"]["status"]]

--- a/report_app/main/views.py
+++ b/report_app/main/views.py
@@ -340,6 +340,7 @@ def search_public_repositories():
         search_results=search_results
     )
 
+
 @main.route("/public-report/<repository_name>", methods=["GET"])
 def display_individual_public_report(repository_name: str):
     """View the GitHub standards report for a repository"""
@@ -355,6 +356,7 @@ def display_individual_public_report(repository_name: str):
         abort(404)
     return render_template("/github-report.html", report=report)
 
+
 @main.route("/compliant-public-repositories.html", methods=["GET"])
 def display_compliant_public_repositories():
     """View all repositories that adhere to the MoJ GitHub standards"""
@@ -367,6 +369,7 @@ def display_compliant_public_repositories():
 
     return render_template("/compliant-public-repositories.html", compliant_repos=compliant_repositories)
 
+
 @main.route("/non-compliant-public-repositories.html", methods=["GET"])
 def display_noncompliant_public_repositories():
     """View all repositories that do not adhere to the MoJ GitHub standards"""
@@ -377,10 +380,10 @@ def display_noncompliant_public_repositories():
         region=os.getenv("DYNAMODB_REGION"),
     ).get_all_non_compliant_repository_reports()
 
-
     non_compliant_repositories = [repo for repo in non_compliant if not repo['data']['is_private']]
 
     return render_template("/non-compliant-public-repositories.html", non_compliant_repos=non_compliant_repositories)
+
 
 @main.route("/all-public-repositories.html", methods=["GET"])
 def display_all_public_repositories():
@@ -392,8 +395,6 @@ def display_all_public_repositories():
         region=os.getenv("DYNAMODB_REGION"),
     ).get_all_repository_reports()
 
-
     public_reports = [repo for repo in all_reports if not repo['data']['is_private']]
 
     return render_template("/all-public-repositories.html", public_reports=public_reports)
-

--- a/report_app/main/views.py
+++ b/report_app/main/views.py
@@ -356,7 +356,7 @@ def display_individual_public_report(repository_name: str):
     return render_template("/github-report.html", report=report)
 
 @main.route("/compliant-public-repositories.html", methods=["GET"])
-def display_all_compliant_public_repositories():
+def display_compliant_public_repositories():
     """View all repositories that adhere to the MoJ GitHub standards"""
     compliant_repositories = ReportDatabase(
         table_name=os.getenv("DYNAMODB_TABLE_NAME"),
@@ -368,7 +368,7 @@ def display_all_compliant_public_repositories():
     return render_template("/compliant-public-repositories.html", compliant_repos=compliant_repositories)
 
 @main.route("/non-compliant-public-repositories.html", methods=["GET"])
-def display_all_noncompliant_public_repositories():
+def display_noncompliant_public_repositories():
     """View all repositories that do not adhere to the MoJ GitHub standards"""
     non_compliant = ReportDatabase(
         table_name=os.getenv("DYNAMODB_TABLE_NAME"),

--- a/report_app/main/views.py
+++ b/report_app/main/views.py
@@ -331,7 +331,7 @@ def search_public_repositories():
         """
         <ul class="govuk-list">
             {% for repo in search_results %}
-                <p><a href="{{ repo.url }}">{{ repo.name }}</a></p>
+                <p><a href="/public-report/{{ repo.name }}">{{ repo.name }}</a></p>
             {% else %}
                 <p>No results found</p>
             {% endfor %}

--- a/report_app/main/views.py
+++ b/report_app/main/views.py
@@ -1,4 +1,5 @@
 import logging
+import datetime
 import os
 from functools import wraps
 from urllib.parse import quote_plus, urlencode
@@ -301,7 +302,7 @@ def public_github_repositories():
     non_compliant = len(non_compliant_repos)
 
     return render_template("public-github-repositories.html",
-                           last_updated="today",
+                           last_updated=datetime.datetime.now().strftime("%d %B %Y"),
                            total=len(public_repositories),
                            compliant=compliant,
                            non_compliant=non_compliant)

--- a/report_app/main/views.py
+++ b/report_app/main/views.py
@@ -340,7 +340,6 @@ def search_public_repositories():
         search_results=search_results
     )
 
-
 @main.route("/public-report/<repository_name>", methods=["GET"])
 def display_individual_public_report(repository_name: str):
     """View the GitHub standards report for a repository"""
@@ -355,3 +354,46 @@ def display_individual_public_report(repository_name: str):
         logger.warning("display_individual_public_report(): repository not found")
         abort(404)
     return render_template("/github-report.html", report=report)
+
+@main.route("/compliant-public-repositories.html", methods=["GET"])
+def display_all_compliant_public_repositories():
+    """View all repositories that adhere to the MoJ GitHub standards"""
+    compliant_repositories = ReportDatabase(
+        table_name=os.getenv("DYNAMODB_TABLE_NAME"),
+        access_key=os.getenv("DYNAMODB_ACCESS_KEY_ID"),
+        secret_key=os.getenv("DYNAMODB_SECRET_ACCESS_KEY"),
+        region=os.getenv("DYNAMODB_REGION"),
+    ).get_all_compliant_repository_reports()
+
+    return render_template("/compliant-public-repositories.html", compliant_repos=compliant_repositories)
+
+@main.route("/non-compliant-public-repositories.html", methods=["GET"])
+def display_all_noncompliant_public_repositories():
+    """View all repositories that do not adhere to the MoJ GitHub standards"""
+    non_compliant = ReportDatabase(
+        table_name=os.getenv("DYNAMODB_TABLE_NAME"),
+        access_key=os.getenv("DYNAMODB_ACCESS_KEY_ID"),
+        secret_key=os.getenv("DYNAMODB_SECRET_ACCESS_KEY"),
+        region=os.getenv("DYNAMODB_REGION"),
+    ).get_all_non_compliant_repository_reports()
+
+
+    non_compliant_repositories = [repo for repo in non_compliant if not repo['data']['is_private']]
+
+    return render_template("/non-compliant-public-repositories.html", non_compliant_repos=non_compliant_repositories)
+
+@main.route("/all-public-repositories.html", methods=["GET"])
+def display_all_public_repositories():
+    """View all repositories that do not adhere to the MoJ GitHub standards"""
+    all_reports = ReportDatabase(
+        table_name=os.getenv("DYNAMODB_TABLE_NAME"),
+        access_key=os.getenv("DYNAMODB_ACCESS_KEY_ID"),
+        secret_key=os.getenv("DYNAMODB_SECRET_ACCESS_KEY"),
+        region=os.getenv("DYNAMODB_REGION"),
+    ).get_all_repository_reports()
+
+
+    public_reports = [repo for repo in all_reports if not repo['data']['is_private']]
+
+    return render_template("/all-public-repositories.html", public_reports=public_reports)
+

--- a/report_app/templates/all-public-repositories.html
+++ b/report_app/templates/all-public-repositories.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="govuk-heading-xl">Public GitHub Repositories Status</h1>
+
+<div class="govuk-grid-row">
+    {% for repo in public_reports %}
+        <div class="govuk-grid-column-one-third">
+            <div class="govuk-card" style="margin-bottom: 20px;">
+                <div class="govuk-card__body">
+                    <h3 class="govuk-card__heading govuk-heading-m">
+                        <a class="govuk-link" href="/public-report/{{ repo.name }}">{{ repo.name }}</a>
+                    </h3>
+                    <p class="govuk-body {{ 'govuk-tag govuk-tag--green' if repo.data.status else 'govuk-tag govuk-tag--red' }}">
+                        {{ "Compliant" if repo.data.status else "Non-Compliant" }}
+                    </p>
+                </div>
+            </div>
+        </div>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/report_app/templates/compliant-public-repositories.html
+++ b/report_app/templates/compliant-public-repositories.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="govuk-heading-xl">Compliant Public GitHub Repositories</h1>
+
+<table class="govuk-table">
+    <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Repository Name</th>
+            <th scope="col" class="govuk-table__header">Link</th>
+        </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+        {% for repo in compliant_repos %}
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">{{ repo.name }}</td>
+                <td class="govuk-table__cell"><a href="{{ repo.data.url }}">GitHub Link</a></td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/report_app/templates/non-compliant-public-repositories.html
+++ b/report_app/templates/non-compliant-public-repositories.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="govuk-heading-xl">Non-Compliant GitHub Repositories</h1>
+
+<table class="govuk-table">
+    <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Repository Name</th>
+            <th scope="col" class="govuk-table__header">Link</th>
+            <th scope="col" class="govuk-table__header">Infractions</th>
+        </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+        {% for repo in non_compliant_repos %}
+            <tr class="govuk-table__row">
+					<td class="govuk-table__cell"><a href="/public-report/{{ repo.name }}">{{ repo.name }}</td>
+                <td class="govuk-table__cell"><a href="{{ repo.data.url }}">GitHub Link</a></td>
+                <td class="govuk-table__cell">
+                    <ul>
+                        {% for infraction in repo.data.infractions %}
+                            <li>{{ infraction }}</li>
+                        {% endfor %}
+                    </ul>
+                </td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endblock %}
+

--- a/report_app/templates/public-github-repositories.html
+++ b/report_app/templates/public-github-repositories.html
@@ -1,16 +1,16 @@
 {% extends "base.html" %}
 
 {% block content %}
-<h1 class="govuk-heading-l">
-    <span class="govuk-caption-xl">Repositories report</span>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.5.1/dist/chart.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+ <script src="https://cdn.jsdelivr.net/npm/chart.js@3.5.1/dist/chart.min.js"></script>
+ <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0"></script>
+ <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+<h1 class="govuk-heading-l">Repositories report</h1>
 
-    {% if updated_at %}
-    <span class="govuk-caption-m">Updated: {{ updated_at }} UTC</span>
-    {% endif %}
-</h1>
+<h2 class="govuk-heading-m">Last updated: {{ last_updated }}</h2>
+
+<p class="govuk-body">
+	 This report shows the number of repositories that are compliant and non-compliant with the Ministry of Justice technical standards.
+</p>
 
 <p class="govuk-body">
     Out of {{ total }} repositories, {{ compliant }} are compliant and {{ non_compliant }} are non-compliant.
@@ -94,6 +94,8 @@
 });
 </script>
 
+
 {{ super() }}
 
 {% endblock %}
+

--- a/report_app/templates/public-github-repositories.html
+++ b/report_app/templates/public-github-repositories.html
@@ -4,12 +4,12 @@
  <script src="https://cdn.jsdelivr.net/npm/chart.js@3.5.1/dist/chart.min.js"></script>
  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0"></script>
  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-<h1 class="govuk-heading-l">Repositories report</h1>
+<h1 class="govuk-heading-l">Public Repositories report</h1>
 
 <h2 class="govuk-heading-m">Last updated: {{ last_updated }}</h2>
 
 <p class="govuk-body">
-	 This report shows the number of repositories that are compliant and non-compliant with the Ministry of Justice technical standards.
+	 This report shows the number of public GitHub repositories that are compliant and non-compliant with the Ministry of Justice technical standards.
 </p>
 
 <p class="govuk-body">

--- a/report_app/templates/public-github-repositories.html
+++ b/report_app/templates/public-github-repositories.html
@@ -13,7 +13,7 @@
 </p>
 
 <p class="govuk-body">
-    Out of {{ total }} repositories, {{ compliant }} are compliant and {{ non_compliant }} are non-compliant.
+Out of {{ total }} <a href="/all-public-repositories.html">public repositories</a>, {{ compliant }} are <a href="/compliant-public-repositories.html">compliant</a> and {{ non_compliant }} are <a href="/non-compliant-public-repositories.html">non-compliant<a>.
 </p>
 
 <p class="govuk-body">
@@ -87,7 +87,7 @@
         },
         onClick: function(evt, activeElements) {
             var elementIndex = activeElements[0].index;
-            var url = this.data.labels[elementIndex] === "Compliant" ? '/compliant' : '/non-compliant';
+            var url = this.data.labels[elementIndex] === "Compliant" ? '/compliant-public-repositories.html' : '/non-compliant-public-repositories.html';
             window.location.href = url;
         }
     }

--- a/tests/test_report_database.py
+++ b/tests/test_report_database.py
@@ -97,6 +97,11 @@ class TestReportDatabase(unittest.TestCase):
     def test_get_all_items_with_no_items(self):
         self.assertEqual(len(self.report_database.get_all_repository_reports()), 0)
 
+    def test_get_all_compliant_and_non_compliant_reports(self):
+        self.report_database.add_repository_report('test_key', {'name': 'test_key', 'status': True})
+        self.report_database.add_repository_report('test_key2', {'name': 'test_key2', 'status': False})
+        self.assertEqual(len(self.report_database.get_all_compliant_repository_reports()), 1)
+        self.assertEqual(len(self.report_database.get_all_non_compliant_repository_reports()), 1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_report_database.py
+++ b/tests/test_report_database.py
@@ -103,5 +103,6 @@ class TestReportDatabase(unittest.TestCase):
         self.assertEqual(len(self.report_database.get_all_compliant_repository_reports()), 1)
         self.assertEqual(len(self.report_database.get_all_non_compliant_repository_reports()), 1)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -190,8 +190,25 @@ class TestGitHubReports(unittest.TestCase):
 
     def test_successful_github_repositories_return(self):
         response = self.client.get(self.landing_endpoint)
-        self.assertIn(b'0 are compliant', response.data)
-        self.assertIn(b'1 are non-compliant', response.data)
+        self.assertIn(b'0 are <a href="/compliant', response.data)
+        self.assertIn(b'1 are <a href="/non-compliant', response.data)
+
+    def test_display_compliant_public_repositories(self):
+        response = self.client.get("/compliant-public-repositories.html")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(b'test-public-repository', response.data)
+
+    def test_display_noncompliant_public_repositories(self):
+        response = self.client.get("/non-compliant-public-repositories.html")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'test-public-repository', response.data)
+        self.assertNotIn(b'test-private-repository', response.data)
+
+    def test_display_all_public_repositories(self):
+        response = self.client.get("/all-public-repositories.html")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'test-public-repository', response.data)
+        self.assertNotIn(b'test-private-repository', response.data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Overview
---

This PR connects to https://github.com/ministryofjustice/operations-engineering/issues/2272 and https://github.com/ministryofjustice/operations-engineering/issues/2243 and relates to the addition of three new Flask views and one change (with tests).

View:
1. `report_app/templates/all-public-repositories.html` displays a boxed view of all collected public repositories. It should identify at a glance the mass of repositories and allow users to visually see their repository report.
<img width="1581" alt="Screenshot 2023-07-03 at 19 52 05" src="https://github.com/ministryofjustice/operations-engineering-reports/assets/31217584/ce1e0a16-305b-4c4e-8924-0f02cbf67ad1">

---
2. `report_app/templates/compliant-public-repositories.html` simply captures the name and places it into a table. There wasn't a lot to do here, other than linking it to other pages.
<img width="1108" alt="Screenshot 2023-07-03 at 19 54 58" src="https://github.com/ministryofjustice/operations-engineering-reports/assets/31217584/85387654-9416-474f-bb18-33f741ea858f">

---
3. `report_app/templates/non-compliant-public-repositories.html` will display a table of all offending repositories not meeting the required standards. This links to the report page and displays the current infractions found on the repository.
<img width="1108" alt="Screenshot 2023-07-03 at 19 55 58" src="https://github.com/ministryofjustice/operations-engineering-reports/assets/31217584/3ffdfe62-27f3-40c5-accc-e67157694f4d">

---

Two new tests are also added, which cover all possible user journies.
https://github.com/ministryofjustice/operations-engineering-reports/pull/248/files#diff-3e4c4f1f8ea3351582e7975e2e61c6a465f858035d00bb334909ad553ca08287R110-R119

