### PR TITLE
:white_check_mark: Add environment variables to pass defensive check

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch, MagicMock
+import os
 import unittest
 from moto import mock_dynamodb
 import boto3
@@ -15,6 +16,16 @@ class TestAuth0Authentication(unittest.TestCase):
         self.ctx.push()
         self.client = app.test_client()
         self.auth0_mock = MagicMock()
+
+        os.environ['AUTH0_DOMAIN'] = 'fake'
+        os.environ['AUTH0_CLIENT_ID'] = 'FAKE'
+        os.environ['AUTH0_CLIENT_SECRET'] = 'FAKE'
+
+    def tearDown(self) -> None:
+        self.ctx.pop()
+        os.unsetenv('AUTH0_DOMAIN')
+        os.unsetenv('AUTH0_CLIENT_ID')
+        os.unsetenv('AUTH0_CLIENT_SECRET')
 
     def test_login_redirect(self):
         response = self.client.get('/login')


### PR DESCRIPTION
The auth0 client setup performs a defensive check to ensure the AUTH0 domain is correctly specified. This commit ensures all variables are set with fake values.
