### PR TITLE
✅ Add flask envvars to testing environment

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,4 +21,5 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Test with pytest
         run: |
+          export FLASK_CONFIGURATION=development # Required to set the correct config
           python -m pytest -v

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,5 +21,4 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Test with pytest
         run: |
-          export FLASK_CONFIGURATION=development # Required to set the correct config
-          python -m pytest -v
+          make test

--- a/makefile
+++ b/makefile
@@ -21,7 +21,7 @@ format: venv
 	@venv/bin/black $(source_files)
 
 test:
-	export FLASK_CONFIGURATION=development; python3 -m pytest -v; unset FLASK_CONFIGURATION
+	export FLASK_CONFIGURATION=development; python3 -m pytest -v
 
 clean-test:
 	rm -fr venv

--- a/makefile
+++ b/makefile
@@ -21,7 +21,7 @@ format: venv
 	@venv/bin/black $(source_files)
 
 test:
-	python3 -m pytest -v
+	export FLASK_CONFIGURATION=development; python3 -m pytest -v; unset FLASK_CONFIGURATION
 
 clean-test:
 	rm -fr venv

--- a/report_app/config/development.py
+++ b/report_app/config/development.py
@@ -1,4 +1,5 @@
 """ Config values to be used during development """
+import os
 
 from os import environ
 
@@ -13,3 +14,15 @@ MAIL_FROM_EMAIL = "operations-engineering@digital.justice.gov.uk"
 PORT = 4567
 SSL_REDIRECT = False
 TESTING = True
+
+if not APP_SECRET_KEY:
+    os.environ["APP_SECRET_KEY"] = "dev"
+
+if not AUTH0_CLIENT_ID:
+    os.environ["AUTH0_CLIENT_ID"] = "dev"
+
+if not AUTH0_CLIENT_SECRET:
+    os.environ["AUTH0_CLIENT_SECRET"] = "dev"
+
+if not AUTH0_DOMAIN:
+    os.environ["AUTH0_DOMAIN"] = "dev"

--- a/report_app/main/views.py
+++ b/report_app/main/views.py
@@ -1,9 +1,9 @@
-import logging
 import datetime
+import logging
 import os
+from collections import Counter
 from functools import wraps
 from urllib.parse import quote_plus, urlencode
-from collections import Counter
 
 from authlib.integrations.flask_client import OAuth
 from flask import (Blueprint, abort, current_app, jsonify, redirect,
@@ -28,10 +28,6 @@ def setup_auth0(setup_state):
     Args:
         setup_state (Flask): The Flask app itself
     """
-    if __auth0_not_configured():
-        logger.warning("Auth0 not configured")
-        abort(500, "Auth0 not configured")
-
     app = setup_state.app
     OAuth(app)
     auth0 = app.extensions.get(AUTHLIB_CLIENT)
@@ -44,14 +40,6 @@ def setup_auth0(setup_state):
         },
         server_metadata_url=f'https://{os.getenv("AUTH0_DOMAIN")}/'
         + ".well-known/openid-configuration",
-    )
-
-
-def __auth0_not_configured():
-    return (
-        os.getenv("AUTH0_CLIENT_ID") is None
-        or os.getenv("AUTH0_CLIENT_SECRET") is None
-        or os.getenv("AUTH0_DOMAIN") is None
     )
 
 

--- a/report_app/main/views.py
+++ b/report_app/main/views.py
@@ -118,8 +118,6 @@ def login():
     """
     logger.debug("login()")
     auth0 = current_app.extensions.get(AUTHLIB_CLIENT)
-    if auth0 is None:
-        abort(500, "Auth0 client not found.")
     return auth0.auth0.authorize_redirect(
         redirect_uri=url_for("main.callback", _external=True)
     )


### PR DESCRIPTION
The flask environment requires several environment variables set in a test environment. This PR adds the `FLASK_CONFIGURATION=development` envvar to the `make test` command, which will set a number of variables at runtime. 