### PR TITLE
🔥 Remove the logout button from all pages

### DIFF
--- a/report_app/templates/base.html
+++ b/report_app/templates/base.html
@@ -5,61 +5,46 @@ Operations Engineering Reports
 {% endblock %}
 
 {% block head %}
-  <title>Operations Engineering Reports</title>
-  <!-- Manually set the govuk frontend version in line below and bottom of this file -->
-  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='stylesheets/govuk-frontend-4.3.0.min.css') }}" />
-  <link rel="canonical" href="https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/">
-  <meta property="og:site_name" content="MoJ Operations Engineering Reports" />
-  <meta property="og:title" content="MoJ Operations Engineering Reports" />
-  <meta property="og:type" content="object" />
-  <meta property="og:url" content="https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/" />
+<title>Operations Engineering Reports</title>
+<!-- Manually set the govuk frontend version in line below and bottom of this file -->
+<link rel="stylesheet" type="text/css"
+  href="{{ url_for('static', filename='stylesheets/govuk-frontend-4.3.0.min.css') }}" />
+<link rel="canonical" href="https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/">
+<meta property="og:site_name" content="MoJ Operations Engineering Reports" />
+<meta property="og:title" content="MoJ Operations Engineering Reports" />
+<meta property="og:type" content="object" />
+<meta property="og:url" content="https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/" />
 {% endblock head %}
 
 {% block header %}
-  <div class="app-pane__header toc-open-disabled">
-    <header class="govuk-header app-header" role="banner" data-module="govuk-header">
-      <div class="govuk-header__container govuk-header__container--full-width">
-        <div class="govuk-header__logo">
-          <a class="govuk-header__link govuk-header__link--homepage" href="/home">
-            <span class="govuk-header__product-name">
+<div class="app-pane__header toc-open-disabled">
+  <header class="govuk-header app-header" role="banner" data-module="govuk-header">
+    <div class="govuk-header__container govuk-header__container--full-width">
+      <div class="govuk-header__logo">
+        <a class="govuk-header__link govuk-header__link--homepage" href="/home">
+          <span class="govuk-header__product-name">
             MoJ Operations Engineering Reports
-            </span>
-          </a>
-        </div>
-        <div class="govuk-header__content">
-          <nav class="govuk-header__navigation govuk-header__navigation--end">
-            <ul class="govuk-header__navigation-list">
-              <li class="govuk-header__navigation-item">
-                <a class="govuk-header__link" href="https://github.com/ministryofjustice/operations-engineering-reports">
-                  GitHub
-                </a>
-              </li>
-            </ul>
-          </nav>
-        </div>
+          </span>
+        </a>
       </div>
-    </header>
-  </div>
-{% endblock %}
-
-{% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      {% if session %}
-        <a href="/logout" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
-        Logout
-        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19"
-          viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-          <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-        </svg>
-      {% endif %}
-      </a>
+      <div class="govuk-header__content">
+        <nav class="govuk-header__navigation govuk-header__navigation--end">
+          <ul class="govuk-header__navigation-list">
+            <li class="govuk-header__navigation-item">
+              <a class="govuk-header__link" href="https://github.com/ministryofjustice/operations-engineering-reports">
+                GitHub
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
     </div>
-  </div>
+  </header>
+</div>
 {% endblock %}
 
 {% block bodyEnd %}
-  <!-- Manually set the govuk frontend version in the line below -->
-  <script src="{{ url_for('static', filename='javascript/govuk-frontend-4.3.0.min.js') }}"> </script>
-  <script>window.GOVUKFrontend.initAll()</script>
+<!-- Manually set the govuk frontend version in the line below -->
+<script src="{{ url_for('static', filename='javascript/govuk-frontend-4.3.0.min.js') }}"> </script>
+<script>window.GOVUKFrontend.initAll()</script>
 {% endblock bodyEnd %}


### PR DESCRIPTION
The global base logout button has a place on only a few of our pages. It makes navigation confusing and needs to look better.

<img width="953" alt="Screenshot 2023-07-10 at 11 33 44" src="https://github.com/ministryofjustice/operations-engineering-reports/assets/31217584/fd7398f4-1a08-4590-84e5-6dcca2c15072">


This PR removes the logout button from the base template and formats the HTML code.
