### PR TITLE
🐛 Fix Gunicorn timeout error

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -20,4 +20,7 @@ USER 1017
 
 EXPOSE 4567
 
-ENTRYPOINT gunicorn --bind 0.0.0.0:4567 operations_engineering_reports:app
+ENTRYPOINT gunicorn operations_engineering_reports:app \
+--bind 0.0.0.0:4567 \
+--timeout 120
+


### PR DESCRIPTION
An error in gunicorn consistently causes a worker to fail. When sending large amounts of data to the api, an error: `[7] [CRITICAL] WORKER TIMEOUT` appears and it's container is restarted. Changing the timeout to 120 should allow the connection to remain open long enough for a large POST request to complete.