### PR TITLE
🚀 Update Helm chart to support multiple hostnames

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -68,4 +68,4 @@ jobs:
             --set application.encryptionKey=${OPS_ENG_REPORTS_ENCRYPT_KEY} \
             --set application.apiKey=${OPERATIONS_ENGINEERING_REPORTS_API_KEY} \
             --set image.repository=754256621582.dkr.ecr.eu-west-2.amazonaws.com/${ECR_NAME} \
-            --set ingress.host=operations-engineering-reports-dev.cloud-platform.service.justice.gov.uk
+            --set ingress.hosts={operations-engineering-reports-dev.cloud-platform.service.justice.gov.uk}

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -72,7 +72,7 @@ jobs:
             --set application.encryptionKey=${OPS_ENG_REPORTS_ENCRYPT_KEY} \
             --set application.apiKey=${OPERATIONS_ENGINEERING_REPORTS_API_KEY} \
             --set image.repository=754256621582.dkr.ecr.eu-west-2.amazonaws.com/${ECR_NAME} \
-            --set ingress.host=operations-engineering-reports-prod.cloud-platform.service.justice.gov.uk
+            --set ingress.hosts={operations-engineering-reports-prod.cloud-platform.service.justice.gov.uk,operations-engineering-reports2.cloud-platform.service.justice.gov.uk}
       - name: Report failure to Slack
         if: always()
         uses: ravsamhq/notify-slack-action@v2

--- a/helm/operations-engineering-reports/templates/ingress.yaml
+++ b/helm/operations-engineering-reports/templates/ingress.yaml
@@ -14,9 +14,10 @@ spec:
   ingressClassName: {{ .Values.ingress.className }}
   tls:
     - hosts:
-        - {{ .Values.ingress.host }}
+        - {{ .Values.ingress.hosts }}
   rules:
-    - host: {{ .Values.ingress.host }}
+  {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
       http:
         paths:
           - path: /

--- a/helm/operations-engineering-reports/values.yaml
+++ b/helm/operations-engineering-reports/values.yaml
@@ -55,7 +55,9 @@ ingress:
   enabled: true
   className: "default"
   colour: "green"
-  host: internal.dev.fake
+  hosts:
+    - host1.example.com
+    - host2.example.com
 
 resources:
   {}


### PR DESCRIPTION
- Modified the Ingress template to allow for multiple hostnames
- Updated the installation command to accept a comma-separated list of hostnames at runtime
- Provided flexibility to specify a single hostname or multiple hostnames as needed

This commit enhances the Helm chart to accommodate multiple hostnames for the Ingress resource. By updating the Ingress template and the installation command, users can now configure multiple hostnames for routing traffic to the application. Additionally, the changes maintain compatibility with specifying a single hostname, providing flexibility in deployment scenarios.