### PR TITLE
:closed_lock_with_key: Set service name to that defined in CP IRSA

### DIFF
--- a/helm/operations-engineering-reports/templates/deployment.yaml
+++ b/helm/operations-engineering-reports/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "operations-engineering-reports.serviceAccountName" . }}
+      serviceAccountName: operations-engineering-reports
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:


### PR DESCRIPTION
Cloud Platform are moving away from long-lived credentials. This means we must use the service account module as defined in this document: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/accessing-aws-apis-and-resources-from-your-namespace.html#using-irsa-in-your-namespace
