### PR TITLE
:green_heart: Fix permission when trying to create a release

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -1,5 +1,8 @@
 name: Deploy to Prod
 
+permissions:
+  contents: write
+
 on:
   push:
     tags:


### PR DESCRIPTION
A 404 error appears when trying to create a release. Making this change will enable it to work according to this link: https://github.com/softprops/action-gh-release/issues/236#issuecomment-1150530128
