### PR TITLE
:wrench: Replace base build with Alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM python:3.11.5-slim
+FROM python:3.12.0-alpine3.17
 
-RUN addgroup --gid 1017 --system appgroup \
-  && adduser --system --uid 1017 --group appgroup
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
-RUN apt update -y && apt dist-upgrade -y && apt install -y
+RUN \
+  apk add \
+  --no-cache \
+  --no-progress \
+  --update \
+  build-base
 
-WORKDIR /home/operations-engineering-reports
+WORKDIR /app/operations-engineering-reports
 
 COPY requirements.txt requirements.txt
 COPY report_app report_app
@@ -16,11 +20,11 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-USER 1017
+USER appuser
 
 EXPOSE 4567
 
 ENTRYPOINT gunicorn operations_engineering_reports:app \
---bind 0.0.0.0:4567 \
---timeout 120
+  --bind 0.0.0.0:4567 \
+  --timeout 120
 

--- a/docker-test.yaml
+++ b/docker-test.yaml
@@ -4,11 +4,6 @@ commandTests:
     command: "which"
     args: ["gunicorn"]
     expectedOutput: ["/usr/local/bin/gunicorn"]
-  - name: "apt-get upgrade"
-    command: "apt-get"
-    args: ["-qqs", "upgrade"]
-    excludedOutput: [".*Inst.*Security.* | .*Security.*Inst.*"]
-    excludedError: [".*Inst.*Security.* | .*Security.*Inst.*"]
   - name: "python"
     command: "which"
     args: ["python"]
@@ -19,12 +14,12 @@ commandTests:
     expectedOutput: ["/usr/local/bin/pip3"]
   - name: "pwd"
     command: "pwd"
-    expectedOutput: ["/home/operations-engineering-reports"]
+    expectedOutput: ["/app/operations-engineering-reports"]
 metadataTest:
   envVars:
   exposedPorts: ["4567"]
 containerRunOptions:
-  user: "appgroup"
+  user: "appuser"
   privileged: false
 globalEnvVars:
   - key: "PYTHONDONTWRITEBYTECODE"


### PR DESCRIPTION
This is due to a few trivy vulns triggering that debian are too slow to patch.

connect to https://github.com/ministryofjustice/operations-engineering/issues/3758
