### PR TITLE
:wrench: Bump base container to 3.18 and upgrade crypto pkgs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.0-alpine3.17
+FROM python:3.12.0-alpine3.18
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup -u 1051
 
@@ -7,6 +7,9 @@ RUN \
   --no-cache \
   --no-progress \
   --update \
+  --upgrade \
+  libcrypto3 \
+  libssl3 \
   build-base
 
 WORKDIR /app/operations-engineering-reports


### PR DESCRIPTION
After running a local trivy container scan, this mitigates CVE2023-5363.
Results of previous trivy scan:

```bash
└─> docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
        aquasec/trivy:latest image test-report --severity HIGH,CRITICAL
2023-11-20T10:51:19.187Z        INFO    Need to update DB
2023-11-20T10:51:19.187Z        INFO    DB Repository: ghcr.io/aquasecurity/trivy-db
2023-11-20T10:51:19.187Z        INFO    Downloading DB...
6.26 MiB / 40.91 MiB [--------->____________________________________________________] 15.31% ? p/s ?14.03 MiB / 40.91 MiB [-------------------->________________________________________] 34.30% ? p/s ?15.91 MiB / 40.91 MiB [----------------------->_____________________________________] 38.88% ? p/s ?22.47 MiB / 40.91 MiB [-------------------------->_____________________] 54.92% 27.00 MiB p/s ETA 0s27.26 MiB / 40.91 MiB [------------------------------->________________] 66.63% 27.00 MiB p/s ETA 0s31.40 MiB / 40.91 MiB [------------------------------------>___________] 76.74% 27.00 MiB p/s ETA 0s38.36 MiB / 40.91 MiB [--------------------------------------------->__] 93.76% 26.97 MiB p/s ETA 0s40.91 MiB / 40.91 MiB [---------------------------------------------->] 100.00% 26.97 MiB p/s ETA 0s40.91 MiB / 40.91 MiB [---------------------------------------------->] 100.00% 26.97 MiB p/s ETA 0s40.91 MiB / 40.91 MiB [---------------------------------------------->] 100.00% 25.50 MiB p/s ETA 0s40.91 MiB / 40.91 MiB [---------------------------------------------->] 100.00% 25.50 MiB p/s ETA 0s40.91 MiB / 40.91 MiB [---------------------------------------------->] 100.00% 25.50 MiB p/s ETA 0s40.91 MiB / 40.91 MiB [-------------------------------------------------] 100.00% 17.19 MiB p/s 2.6s2023-11-20T10:51:23.722Z      INFO    Vulnerability scanning is enabled
2023-11-20T10:51:23.722Z        INFO    Secret scanning is enabled
2023-11-20T10:51:23.722Z        INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-11-20T10:51:23.722Z        INFO    Please see also https://aquasecurity.github.io/trivy/v0.46/docs/scanner/secret/#recommendation for faster secret detection
2023-11-20T10:51:28.046Z        INFO    Detected OS: alpine
2023-11-20T10:51:28.046Z        INFO    Detecting Alpine vulnerabilities...
2023-11-20T10:51:28.047Z        INFO    Number of language-specific files: 1
2023-11-20T10:51:28.047Z        INFO    Detecting python-pkg vulnerabilities...

test-report (alpine 3.18.4)
===========================
Total: 4 (HIGH: 4, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Status │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ fixed  │ 3.1.3-r0          │ 3.1.4-r0      │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
│            ├───────────────┤          │        │                   ├───────────────┼────────────────────────────────────────────────────────┤
│            │ CVE-2023-5678 │          │        │                   │ 3.1.4-r1      │ openssl: Generating excessively long X9.42 DH keys or  │
│            │               │          │        │                   │               │ checking excessively long X9.42...                     │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5678              │
├────────────┼───────────────┤          │        │                   ├───────────────┼────────────────────────────────────────────────────────┤
│ libssl3    │ CVE-2023-5363 │          │        │                   │ 3.1.4-r0      │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
│            ├───────────────┤          │        │                   ├───────────────┼────────────────────────────────────────────────────────┤
│            │ CVE-2023-5678 │          │        │                   │ 3.1.4-r1      │ openssl: Generating excessively long X9.42 DH keys or  │
│            │               │          │        │                   │               │ checking excessively long X9.42...                     │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5678              │
└────────────┴───────────────┴──────────┴────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

```
