### PR TITLE
✨ Add `libffi-dev` to Docker build to resolve local build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12.0-alpine3.18
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup -u 1051
 
-RUN apk add --no-cache --no-progress build-base \
+RUN apk add --no-cache --no-progress build-base libffi-dev \
   && apk update \
   && apk upgrade --no-cache --available
 
@@ -20,7 +20,6 @@ ENV PYTHONUNBUFFERED 1
 USER 1051
 
 EXPOSE 4567
-
 ENTRYPOINT gunicorn operations_engineering_reports:app \
   --bind 0.0.0.0:4567 \
   --timeout 120


### PR DESCRIPTION
## 👀 Purpose
- Oddly, this library is included in the base image - but I can't seem to find it when spinning up the image locally which causes Docker build issues locally

## ♻️ What's changed
- Explicitly add `libffi-dev` to the image to resolve local build issue

