### PR TITLE
:pencil2: Update URLs, Python version and repository details in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![repo standards badge](https://img.shields.io/endpoint?labelColor=231f20&color=005ea5&style=for-the-badge&label=MoJ%20Compliant&url=https%3A%2F%2Foperations-engineering-reports-prod.cloud-platform.service.justice.gov.uk%2Fapi%2Fv1%2Fcompliant_public_repositories%2Fendpoint%2Foperations-engineering-reports&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAABmJLR0QA/wD/AP+gvaeTAAAHJElEQVRYhe2YeYyW1RWHnzuMCzCIglBQlhSV2gICKlHiUhVBEAsxGqmVxCUUIV1i61YxadEoal1SWttUaKJNWrQUsRRc6tLGNlCXWGyoUkCJ4uCCSCOiwlTm6R/nfPjyMeDY8lfjSSZz3/fee87vnnPu75z3g8/kM2mfqMPVH6mf35t6G/ZgcJ/836Gdug4FjgO67UFn70+FDmjcw9xZaiegWX29lLLmE3QV4Glg8x7WbFfHlFIebS/ANj2oDgX+CXwA9AMubmPNvuqX1SnqKGAT0BFoVE9UL1RH7nSCUjYAL6rntBdg2Q3AgcAo4HDgXeBAoC+wrZQyWS3AWcDSUsomtSswEtgXaAGWlVI2q32BI0spj9XpPww4EVic88vaC7iq5Hz1BvVf6v3qe+rb6ji1p3pWrmtQG9VD1Jn5br+Knmm70T9MfUh9JaPQZu7uLsR9gEsJb3QF9gOagO7AuUTom1LpCcAkoCcwQj0VmJregzaipA4GphNe7w/MBearB7QLYCmlGdiWSm4CfplTHwBDgPHAFmB+Ah8N9AE6EGkxHLhaHU2kRhXc+cByYCqROs05NQq4oR7Lnm5xE9AL+GYC2gZ0Jmjk8VLKO+pE4HvAyYRnOwOH5N7NhMd/WKf3beApYBWwAdgHuCLn+tatbRtgJv1awhtd838LEeq30/A7wN+AwcBt+bwpD9AdOAkYVkpZXtVdSnlc7QI8BlwOXFmZ3oXkdxfidwmPrQXeA+4GuuT08QSdALxC3OYNhBe/TtzON4EziZBXD36o+q082BxgQuqvyYL6wtBY2TyEyJ2DgAXAzcC1+Xxw3RlGqiuJ6vE6QS9VGZ/7H02DDwAvELTyMDAxbfQBvggMAAYR9LR9J2cluH7AmnzuBowFFhLJ/wi7yiJgGXBLPq8A7idy9kPgvAQPcC9wERHSVcDtCfYj4E7gr8BRqWMjcXmeB+4tpbyG2kG9Sl2tPqF2Uick8B+7szyfvDhR3Z7vvq/2yqpynnqNeoY6v7LvevUU9QN1fZ3OTeppWZmeyzRoVu+rhbaHOledmoQ7LRd3SzBVeUo9Wf1DPs9X90/jX8m/e9Rn1Mnqi7nuXXW5+rK6oU7n64mjszovxyvVh9WeDcTVnl5KmQNcCMwvpbQA1xE8VZXhwDXAz4FWIkfnAlcBAwl6+SjD2wTcmPtagZnAEuA3dTp7qyNKKe8DW9UeBCeuBsbsWKVOUPvn+MRKCLeq16lXqLPVFvXb6r25dlaGdUx6cITaJ8fnpo5WI4Wuzcjcqn5Y8eI/1F+n3XvUA1N3v4ZamIEtpZRX1Y6Z/DUK2g84GrgHuDqTehpBCYend94jbnJ34DDgNGArQT9bict3Y3p1ZCnlSoLQb0sbgwjCXpY2blc7llLW1UAMI3o5CD4bmuOlwHaC6xakgZ4Z+ibgSxnOgcAI4uavI27jEII7909dL5VSrimlPKgeQ6TJCZVQjwaOLaW8BfyWbPEa1SaiTH1VfSENd85NDxHt1plA71LKRvX4BDaAKFlTgLeALtliDUqPrSV6SQCBlypgFlbmIIrCDcAl6nPAawmYhlLKFuB6IrkXAadUNj6TXlhDcCNEB/Jn4FcE0f4UWEl0NyWNvZxGTs89z6ZnatIIrCdqcCtRJmcCPwCeSN3N1Iu6T4VaFhm9n+riypouBnepLsk9p6p35fzwvDSX5eVQvaDOzjnqzTl+1KC53+XzLINHd65O6lD1DnWbepPBhQ3q2jQyW+2oDkkAtdt5udpb7W+Q/OFGA7ol1zxu1tc8zNHqXercfDfQIOZm9fR815Cpt5PnVqsr1F51wI9QnzU63xZ1o/rdPPmt6enV6sXqHPVqdXOCe1rtrg5W7zNI+m712Ir+cer4POiqfHeJSVe1Raemwnm7xD3mD1E/Z3wIjcsTdlZnqO8bFeNB9c30zgVG2euYa69QJ+9G90lG+99bfdIoo5PU4w362xHePxl1slMab6tV72KUxDvzlAMT8G0ZohXq39VX1bNzzxij9K1Qb9lhdGe931B/kR6/zCwY9YvuytCsMlj+gbr5SemhqkyuzE8xau4MP865JvWNuj0b1YuqDkgvH2GkURfakly01Cg7Cw0+qyXxkjojq9Lw+vT2AUY+DlF/otYq1Ixc35re2V7R8aTRg2KUv7+ou3x/14PsUBn3NG51S0XpG0Z9PcOPKWSS0SKNUo9Rv2Mmt/G5WpPF6pHGra7Jv410OVsdaz217AbkAPX3ubkm240belCuudT4Rp5p/DyC2lf9mfq1iq5eFe8/lu+K0YrVp0uret4nAkwlB6vzjI/1PxrlrTp/oNHbzTJI92T1qAT+BfW49MhMg6JUp7ehY5a6Tl2jjmVvitF9fxo5Yq8CaAfAkzLMnySt6uz/1k6bPx59CpCNxGfoSKA30IPoH7cQXdArwCOllFX/i53P5P9a/gNkKpsCMFRuFAAAAABJRU5ErkJggg==)](https://operations-engineering-reports-prod.cloud-platform.service.justice.gov.uk/public-report/operations-engineering-reports)
 
-This repository houses our GitHub repository standards reports flask application, developed and maintained by the Ministry of Justice's [Operations Engineering Team](https://operations-engineering.service.justice.gov.uk). It provides a unified platform to visualise and track the compliance of GitHub repositories with the GitHub Repository Standards as defined by the Ministry of Justice.
+This repository houses our GitHub repository standards reports flask application, developed and maintained by the Ministry of Justice's [Operations Engineering Team](https://user-guide.operations-engineering.service.justice.gov.uk). It provides a unified platform to visualise and track the compliance of GitHub repositories with the [GitHub Repository Standards](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/mojrepostandards.html) as defined by the Ministry of Justice.
 
 ## Table of Contents
 
@@ -15,7 +15,7 @@ This repository houses our GitHub repository standards reports flask application
 
 To develop, deploy or run this app you will need to install:
 
-- [Python 3.11](https://www.python.org/downloads/release/python-3110/)
+- [Python >= 3.11](https://www.python.org/downloads/release/python-3110/)
 - [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) _(Optional, for running a local AWS DynamoDB instance or development/production servers with Docker Compose)_
 - [Helm](https://helm.sh/) and [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) _(Optional, for deploying to Cloud Platform)_
 
@@ -23,21 +23,21 @@ Note: This project uses AWS DynamoDB for data storage. While it's not necessary 
 
 ## Reports
 
-At the Ministry of Justice, all our source code is open by default and stored on GitHub. We believe in transparency and accessibility in our codebase, and we've established some key standards to ensure we uphold these principles. The guidelines outlined in the [technical standards documentation](https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html#outside-collaborator) help us maintain a secure, transparent and collaborative codebase. Adhering to these standards is crucial to ensure that our GitHub repositories remain accessible, safe, and easy to contribute to.
+At the Ministry of Justice, all our source code is open by default and stored on GitHub. We believe in transparency and accessibility in our codebase, and we've established some key standards to ensure we uphold these principles. The guidelines outlined in the [technical standards documentation](https://technical-guidance.service.justice.gov.uk/documentation/standards/storing-source-code.html#storing-source-code) help us maintain a secure, transparent and collaborative codebase. Adhering to these standards is crucial to ensure that our GitHub repositories remain accessible, safe, and easy to contribute to.
 
-For more information, please review the detailed MoJ GitHub standards [here](https://operations-engineering.service.justice.gov.uk/documentation/services/repository-standards.html#github-repository-standards-in-the-ministry-of-justice).
+For more information, please review the detailed MoJ GitHub standards [here](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/mojrepostandards.html).
 
 ### What are reports?
 
 GitHub repository standards reports are generated by the Operations Engineering team to track the compliance of GitHub repositories with the MoJ GitHub organisation. These reports are generated using a combination of GitHub's REST and GraphQL API. A report is generated for each repository, and contains the following information:
 
-- **Repository name**: The name of the repository.
-- **Repository URL**: The URL of the repository.
-- **Repository owner**: The owner of the repository.
-- **Repository description**: The description of the repository.
-- **Repository visibility**: The visibility of the repository (public or private).
-- **Repository compliance status**: The compliance status of the repository (compliant or non-compliant).
-- **Repository compliance status reason**: The reason for the repository's compliance status (e.g. missing licence file, missing branch protection rules, etc.).
+- **Repository name**: The name of the GitHub repository.
+- **Repository URL**: The GitHub URL of the repository.
+- **Repository owner**: Whether or not the repository is owned by a team or an individual.
+- **Repository description**: A boolean value that indicates whether a repository has a description.
+- **Repository visibility**: Public or private.
+- **Repository compliance status**: A boolean value that indicates whether a repository is compliant with the MoJ GitHub standards.
+- **Repository compliance status reason**: A list of reasons why a repository is non-compliant with the MoJ GitHub standards.
 
 The report is then used to identify commonalities and trends across the organisation, and to identify areas of improvement. The Operations Engineering team uses this information to provide guidance and support to teams and projects, and to ensure that our GitHub repositories remain accessible, safe, and easy to contribute to.
 
@@ -45,7 +45,7 @@ If you wish to add a criteria to the report, please create an issue or speak to 
 
 ### How do you generate them?
 
-A [GitHub action](https://github.com/ministryofjustice/operations-engineering/blob/main/.github/workflows/generate-github-standards-report.yaml) runs daily to fetch all repositories in the Ministry of Justice GitHub organisation, and to generate a report for each repository. The report is then stored in an AWS DynamoDB table, and is used to generate the report dashboard.
+A [GitHub action](https://github.com/ministryofjustice/operations-engineering/blob/main/.github/workflows/job-generate-github-standards-report.yaml) runs daily to fetch all repositories in the Ministry of Justice GitHub organisation, and to generate a report for each repository. The report is then stored in an AWS DynamoDB table, and is used to generate the report dashboard.
 
 This can be done manually by running the following command:
 
@@ -58,7 +58,7 @@ python python/report_on_repository_standards.py --org ministryofjustice --oauth-
 
 ### How can I generate test reports?
 
-To generate test data, you can use the test `ministryofjustice` organisation. This organisation contains a number of test repositories that can be used to generate test reports.
+To generate test data, you can use the `ministryofjustice-test` organisation. This organisation contains a number of test repositories that can be used to generate test reports.
 
 ## Development
 


### PR DESCRIPTION
This commit updates several references within the project's README:

- Replace outdated URLs to Operations Engineering Team and GitHub Repository Standards with their updated versions.
- Update Python prerequisite from a fixed 3.11 version to Python version 3.11 or later.
- Revise descriptions of what constitutes a repository report for clarity and accuracy.
- Modify link to GitHub Action that generates the report.
- Changed test organization for generating test reports.

These changes ensure that the README remains accurate and up-to-date with the latest information about the project and its requirements.