### PR TITLE
:whale: Update Dockerfile with health check and additional dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM python:3.12.1-alpine3.18
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup -u 1051
 
-RUN apk add --no-cache --no-progress build-base libffi-dev \
+RUN apk add --no-cache --no-progress \
+  libffi-dev \
+  build-base \
+  curl \
   && apk update \
   && apk upgrade --no-cache --available
 
@@ -20,6 +23,9 @@ ENV PYTHONUNBUFFERED 1
 USER 1051
 
 EXPOSE 4567
+
+HEALTHCHECK --interval=60s --timeout=30s CMD curl -I -XGET http://localhost:4567 || exit 1
+
 ENTRYPOINT gunicorn operations_engineering_reports:app \
   --bind 0.0.0.0:4567 \
   --timeout 120


### PR DESCRIPTION
This commit adds a new `HEALTHCHECK` instruction to our Dockerfile which uses curl to monitor the health of our app at regular intervals. The commit also introduces `curl` as an additional dependency, which gets installed during the docker build process.

We moved the declaration of `build-base` and `libffi-dev` each to their own line for better readability. Furthermore, we have separated out the installation of new packages from the existing chain of package updates and upgrades to keep things clean and separate.