### PR TITLE
:arrow_up: Bump Authlib and requests packages following cve

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-authlib~=1.2.1
+authlib~=1.3.1
 boto3~=1.26.159
 cryptography~=42.0.2
 flask~=3.0.2
@@ -6,7 +6,7 @@ flask-cors
 govuk-frontend-jinja
 gunicorn
 python-dotenv~=1.0.0
-requests~=2.31.0
+requests~=2.32.0
 pytest~=7.4.2
 setuptools~=69.0.3
 botocore~=1.29.159


### PR DESCRIPTION
Both were identified in the latest Trivy run that report the following
cves:
https://github.com/ministryofjustice/operations-engineering-reports/security/code-scanning/9

https://github.com/ministryofjustice/operations-engineering-reports/security/code-scanning/10
