### PR TITLE
:arrow_up: Bump setuptools to 75.2.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ python-dotenv = "~=1.0.0"
 requests = "~=2.32.0"
 botocore = "~=1.29.159"
 jinja2 = "~=3.1.2"
+setuptools = "==75.2.0"
 
 [dev-packages]
 pytest = "~=8.3.3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "69955ac594134790f9860fd002bbcdde60bf2aebe7d44e55afa13fb75e81b510"
+            "sha256": "40ef707d537cbfb7c04d9df2f598497876396b6e889d8608d839df1e948e309a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -474,6 +474,15 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==0.6.2"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:753bb6ebf1f465a1912e19ed1d41f403a79173a9acf66a42e7e6aec45c3c16ec",
+                "sha256:a7fcb66f68b4d9e8e66b42f9876150a3371558f98fa32222ffaa5bced76406f8"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==75.2.0"
         },
         "six": {
             "hashes": [


### PR DESCRIPTION
This pull request includes a small change to the `Pipfile`. The change adds a specific version requirement for the `setuptools` package.

https://github.com/ministryofjustice/operations-engineering-reports/security/code-scanning/11

* [`Pipfile`](diffhunk://#diff-230078d672f10d17463a8a6265cad825b790885898256a3365be90685caac58dR18): Added `setuptools` with version `==75.2.0` to the package dependencies.