### PR TITLE
✨ Add Required Annotations to Migrate Hostname

### DIFF
--- a/helm/operations-engineering-reports/templates/ingress.yaml
+++ b/helm/operations-engineering-reports/templates/ingress.yaml
@@ -13,6 +13,8 @@ metadata:
     external-dns.alpha.kubernetes.io/set-identifier: {{ $fullName }}-{{ $fullName }}-{{ .Values.ingress.colour }}
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     cloud-platform.justice.gov.uk/ignore-external-dns-weight: "true"
+    allow-duplicate-host: "true"
+    allowed-duplicate-ns: "operations-engineering-reports-prod,github-community-prod"
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   tls:


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/github-community/issues/27
- To migrate the legacy domain to the new service, to minimise disruption on existing users

## ♻️ What's changed

- Added required annotations to start migrating the legacy domain to the new service